### PR TITLE
Add tracker support

### DIFF
--- a/go-app-sms.js
+++ b/go-app-sms.js
@@ -165,6 +165,14 @@ go.utils = {
 
 // DATE HELPERS
 
+    get_now: function(config) {
+        if (config.testing_today) {
+            return new moment(config.testing_today).format('YYYY-MM-DD HH:mm:ss');
+        } else {
+            return new moment().format('YYYY-MM-DD HH:mm:ss');
+        }
+    },
+
     get_today: function(config) {
         if (config.testing_today) {
             return new moment(config.testing_today, 'YYYY-MM-DD');

--- a/go-app-ussdapp.js
+++ b/go-app-ussdapp.js
@@ -713,7 +713,7 @@ go.utils_project = {
     close_tracker: function(im, tracker_id) {
         var endpoint = "tracker/"+tracker_id+"/";
         var payload = {
-            "complete": "True",
+            "complete": true,
             "completed_at": go.utils.get_today(im.config)
         };
 
@@ -944,8 +944,7 @@ go.app = function() {
                                 }
 
                                 return go.utils_project
-                                    .log_quiz_answer(self.im, quiz_question, choice.value, choice.label,
-                                        correct ? "True" : "False", response_text, self.im.user.answers.tracker)
+                                    .log_quiz_answer(self.im, quiz_question, choice.value, choice.label, correct, response_text, self.im.user.answers.tracker)
                                     .then(function() {
                                         return {
                                             name: "state_response",

--- a/go-app-ussdapp.js
+++ b/go-app-ussdapp.js
@@ -714,7 +714,7 @@ go.utils_project = {
         var endpoint = "tracker/"+tracker_id+"/";
         var payload = {
             "complete": true,
-            "completed_at": go.utils.get_today(im.config)
+            "completed_at": go.utils.get_today(im.config).format("YYYY-MM-DD")
         };
 
         return go.utils

--- a/go-app-ussdapp.js
+++ b/go-app-ussdapp.js
@@ -165,6 +165,14 @@ go.utils = {
 
 // DATE HELPERS
 
+    get_now: function(config) {
+        if (config.testing_today) {
+            return new moment(config.testing_today).format('YYYY-MM-DD HH:mm:ss');
+        } else {
+            return new moment().format('YYYY-MM-DD HH:mm:ss');
+        }
+    },
+
     get_today: function(config) {
         if (config.testing_today) {
             return new moment(config.testing_today, 'YYYY-MM-DD');
@@ -714,7 +722,7 @@ go.utils_project = {
         var endpoint = "tracker/"+tracker_id+"/";
         var payload = {
             "complete": true,
-            "completed_at": go.utils.get_today(im.config).format("YYYY-MM-DD")
+            "completed_at": go.utils.get_now(im.config)
         };
 
         return go.utils

--- a/go-app-ussdapp.js
+++ b/go-app-ussdapp.js
@@ -710,6 +710,20 @@ go.utils_project = {
         });
     },
 
+    close_tracker: function(im, tracker_id) {
+        var endpoint = "tracker/"+tracker_id+"/";
+        var payload = {
+            "complete": "True",
+            "completed_at": go.utils.get_today(im.config)
+        };
+
+        return go.utils
+            .service_api_call("continuous-learning", "patch", null, payload, endpoint, im)
+            .then(function(json_post_response) {
+                return json_post_response.data;
+        });
+    },
+
     // SMS HELPERS
 
     send_completion_text: function(im, user_id, text_to_add) {
@@ -975,7 +989,11 @@ go.app = function() {
                 .save_quiz_status(self.im)
                 .then(function() {
                     if (self.im.user.answers.quiz_status.completed) {
-                        return self.states.create("state_end_quiz");
+                        return go.utils_project
+                            .close_tracker(self.im, self.im.user.answers.tracker)
+                            .then(function() {
+                                return self.states.create("state_end_quiz");
+                            });
                     } else {
                         return self.states.create("state_quiz");
                     }

--- a/go-app-ussdapp.js
+++ b/go-app-ussdapp.js
@@ -688,6 +688,24 @@ go.utils_project = {
         return go.utils
             .service_api_call("continuous-learning", "post", null, payload, 'tracker/', im)
             .then(function(json_post_response) {
+                return json_post_response.data.tracker_id;
+        });
+    },
+
+    log_quiz_answer: function(im, quiz_question, answer_value, answer_text, answer_correct, response, tracker_id) {
+        var payload = {
+            "question": quiz_question.id,
+            "question_text": quiz_question.question,
+            "answer_value": answer_value,
+            "answer_text": answer_text,
+            "answer_correct": answer_correct,
+            "response_sent": response,
+            "tracker": tracker_id
+        };
+
+        return go.utils
+            .service_api_call("continuous-learning", "post", null, payload, 'answer/', im)
+            .then(function(json_post_response) {
                 return json_post_response.data;
         });
     },
@@ -859,9 +877,11 @@ go.app = function() {
                             ? untaken_quizzes[Math.floor(Math.random() * untaken_quizzes.length)]
                             : untaken_quizzes[0];
 
-                        var tracker_id = go.utils_project.init_tracker(self.im, self.im.user.answers.user_id, quiz_to_take.id);
-
-                        return self.states.create("state_get_quiz_questions", {"quiz":quiz_to_take.id, "tracker":tracker_id});
+                        return go.utils_project
+                            .init_tracker(self.im, self.im.user.answers.user_id, quiz_to_take.id)
+                            .then(function(tracker_id) {
+                                return self.states.create("state_get_quiz_questions", {"quiz": quiz_to_take.id, "tracker": tracker_id});
+                            });
                     } else {
                         return self.states.create("state_end_quiz_status");
                     }
@@ -882,12 +902,14 @@ go.app = function() {
                     self.im.user.set_answer("quiz_status", quiz_status);
                     self.im.user.set_answer("sms_results_text", "");
 
-                    return self.states.create("state_quiz", creator_opts.tracker);
+                    self.im.user.set_answer("tracker", creator_opts.tracker);
+
+                    return self.states.create("state_quiz");
                 });
         });
 
         // ChoiceState
-        self.add("state_quiz", function(name, tracker_id) {
+        self.add("state_quiz", function(name) {
             return go.utils_project
                 // get first question in the now random line-up
                 .get_quiz_question(self.im, self.im.user.answers.quiz_status.questions_remaining[0])
@@ -899,17 +921,24 @@ go.app = function() {
                         choices: go.utils_project.construct_choices(quiz_question.answers),
                         next: function(choice) {
                                 var response_text = "";
-                                if (choice.value === correct_answer) {
+                                var correct = choice.value === correct_answer;
+                                if (correct) {
                                     response_text = quiz_question.response_correct;
                                     self.im.user.answers.quiz_status.questions_answered.push({"question": quiz_question.question, "correct": true});
                                 } else {
                                     response_text = quiz_question.response_incorrect;
                                     self.im.user.answers.quiz_status.questions_answered.push({"question": quiz_question.question, "correct": false});
                                 }
-                                return  {
-                                    name: "state_response",
-                                    creator_opts: response_text
-                                };
+
+                                return go.utils_project
+                                    .log_quiz_answer(self.im, quiz_question, choice.value, choice.label,
+                                        correct ? "True" : "False", response_text, self.im.user.answers.tracker)
+                                    .then(function() {
+                                        return {
+                                            name: "state_response",
+                                            creator_opts: response_text
+                                        };
+                                    });
                         }
                     });
                 });

--- a/go-app-ussdapp.js
+++ b/go-app-ussdapp.js
@@ -894,7 +894,8 @@ go.app = function() {
                         return go.utils_project
                             .init_tracker(self.im, self.im.user.answers.user_id, quiz_to_take.id)
                             .then(function(tracker_id) {
-                                return self.states.create("state_get_quiz_questions", {"quiz": quiz_to_take.id, "tracker": tracker_id});
+                                self.im.user.set_answer("tracker", tracker_id);
+                                return self.states.create("state_get_quiz_questions", quiz_to_take.id);
                             });
                     } else {
                         return self.states.create("state_end_quiz_status");
@@ -903,20 +904,18 @@ go.app = function() {
 
         });
 
-        self.add("state_get_quiz_questions", function(name, creator_opts) {
+        self.add("state_get_quiz_questions", function(name, quiz_id) {
             return go.utils_project
-                .get_quiz(self.im, creator_opts.quiz)
+                .get_quiz(self.im, quiz_id)
                 .then(function(quiz) {
                     // creates a random line-up of questions
                     var random_questions = self.im.config.randomize_questions
                         ? _.shuffle(quiz.questions)
                         : quiz.questions;
 
-                    var quiz_status = go.utils_project.init_quiz_status(creator_opts.quiz, random_questions);
+                    var quiz_status = go.utils_project.init_quiz_status(quiz_id, random_questions);
                     self.im.user.set_answer("quiz_status", quiz_status);
                     self.im.user.set_answer("sms_results_text", "");
-
-                    self.im.user.set_answer("tracker", creator_opts.tracker);
 
                     return self.states.create("state_quiz");
                 });

--- a/src/ussdapp.js
+++ b/src/ussdapp.js
@@ -145,7 +145,8 @@ go.app = function() {
                         return go.utils_project
                             .init_tracker(self.im, self.im.user.answers.user_id, quiz_to_take.id)
                             .then(function(tracker_id) {
-                                return self.states.create("state_get_quiz_questions", {"quiz": quiz_to_take.id, "tracker": tracker_id});
+                                self.im.user.set_answer("tracker", tracker_id);
+                                return self.states.create("state_get_quiz_questions", quiz_to_take.id);
                             });
                     } else {
                         return self.states.create("state_end_quiz_status");
@@ -154,20 +155,18 @@ go.app = function() {
 
         });
 
-        self.add("state_get_quiz_questions", function(name, creator_opts) {
+        self.add("state_get_quiz_questions", function(name, quiz_id) {
             return go.utils_project
-                .get_quiz(self.im, creator_opts.quiz)
+                .get_quiz(self.im, quiz_id)
                 .then(function(quiz) {
                     // creates a random line-up of questions
                     var random_questions = self.im.config.randomize_questions
                         ? _.shuffle(quiz.questions)
                         : quiz.questions;
 
-                    var quiz_status = go.utils_project.init_quiz_status(creator_opts.quiz, random_questions);
+                    var quiz_status = go.utils_project.init_quiz_status(quiz_id, random_questions);
                     self.im.user.set_answer("quiz_status", quiz_status);
                     self.im.user.set_answer("sms_results_text", "");
-
-                    self.im.user.set_answer("tracker", creator_opts.tracker);
 
                     return self.states.create("state_quiz");
                 });

--- a/src/ussdapp.js
+++ b/src/ussdapp.js
@@ -142,7 +142,9 @@ go.app = function() {
                             ? untaken_quizzes[Math.floor(Math.random() * untaken_quizzes.length)]
                             : untaken_quizzes[0];
 
-                        return self.states.create("state_get_quiz_questions", quiz_to_take.id);
+                        var tracker_id = go.utils_project.init_tracker(self.im, self.im.user.answers.user_id, quiz_to_take.id);
+
+                        return self.states.create("state_get_quiz_questions", {"quiz": quiz_to_take.id, "tracker": tracker_id});
                     } else {
                         return self.states.create("state_end_quiz_status");
                     }
@@ -150,30 +152,31 @@ go.app = function() {
 
         });
 
-        self.add("state_get_quiz_questions", function(name, quiz_id) {
+        self.add("state_get_quiz_questions", function(name, creator_opts) {
             return go.utils_project
-                .get_quiz(self.im, quiz_id)
+                .get_quiz(self.im, creator_opts.quiz)
                 .then(function(quiz) {
                     // creates a random line-up of questions
                     var random_questions = self.im.config.randomize_questions
                         ? _.shuffle(quiz.questions)
                         : quiz.questions;
 
-                    var quiz_status = go.utils_project.init_quiz_status(quiz_id, random_questions);
+                    var quiz_status = go.utils_project.init_quiz_status(creator_opts.quiz, random_questions);
                     self.im.user.set_answer("quiz_status", quiz_status);
                     self.im.user.set_answer("sms_results_text", "");
 
-                    return self.states.create("state_quiz");
+                    return self.states.create("state_quiz", creator_opts.tracker);
                 });
         });
 
         // ChoiceState
-        self.add("state_quiz", function(name) {
+        self.add("state_quiz", function(name, tracker_id) {
             return go.utils_project
                 // get first question in the now random line-up
                 .get_quiz_question(self.im, self.im.user.answers.quiz_status.questions_remaining[0])
                 .then(function(quiz_question) {
                     var correct_answer = go.utils_project.get_correct_answer(quiz_question.answers);
+
                     return new ChoiceState(name, {
                         question: quiz_question.question,
                         choices: go.utils_project.construct_choices(quiz_question.answers),
@@ -186,7 +189,6 @@ go.app = function() {
                                     response_text = quiz_question.response_incorrect;
                                     self.im.user.answers.quiz_status.questions_answered.push({"question": quiz_question.question, "correct": false});
                                 }
-
                                 return  {
                                     name: "state_response",
                                     creator_opts: response_text

--- a/src/ussdapp.js
+++ b/src/ussdapp.js
@@ -240,7 +240,11 @@ go.app = function() {
                 .save_quiz_status(self.im)
                 .then(function() {
                     if (self.im.user.answers.quiz_status.completed) {
-                        return self.states.create("state_end_quiz");
+                        return go.utils_project
+                            .close_tracker(self.im, self.im.user.answers.tracker)
+                            .then(function() {
+                                return self.states.create("state_end_quiz");
+                            });
                     } else {
                         return self.states.create("state_quiz");
                     }

--- a/src/ussdapp.js
+++ b/src/ussdapp.js
@@ -195,8 +195,7 @@ go.app = function() {
                                 }
 
                                 return go.utils_project
-                                    .log_quiz_answer(self.im, quiz_question, choice.value, choice.label,
-                                        correct ? "True" : "False", response_text, self.im.user.answers.tracker)
+                                    .log_quiz_answer(self.im, quiz_question, choice.value, choice.label, correct, response_text, self.im.user.answers.tracker)
                                     .then(function() {
                                         return {
                                             name: "state_response",

--- a/src/utils.js
+++ b/src/utils.js
@@ -158,6 +158,14 @@ go.utils = {
 
 // DATE HELPERS
 
+    get_now: function(config) {
+        if (config.testing_today) {
+            return new moment(config.testing_today).format('YYYY-MM-DD HH:mm:ss');
+        } else {
+            return new moment().format('YYYY-MM-DD HH:mm:ss');
+        }
+    },
+
     get_today: function(config) {
         if (config.testing_today) {
             return new moment(config.testing_today, 'YYYY-MM-DD');

--- a/src/utils_project.js
+++ b/src/utils_project.js
@@ -199,7 +199,7 @@ go.utils_project = {
     close_tracker: function(im, tracker_id) {
         var endpoint = "tracker/"+tracker_id+"/";
         var payload = {
-            "complete": "True",
+            "complete": true,
             "completed_at": go.utils.get_today(im.config)
         };
 

--- a/src/utils_project.js
+++ b/src/utils_project.js
@@ -196,6 +196,20 @@ go.utils_project = {
         });
     },
 
+    close_tracker: function(im, tracker_id) {
+        var endpoint = "tracker/"+tracker_id+"/";
+        var payload = {
+            "complete": "True",
+            "completed_at": go.utils.get_today(im.config)
+        };
+
+        return go.utils
+            .service_api_call("continuous-learning", "patch", null, payload, endpoint, im)
+            .then(function(json_post_response) {
+                return json_post_response.data;
+        });
+    },
+
     // SMS HELPERS
 
     send_completion_text: function(im, user_id, text_to_add) {

--- a/src/utils_project.js
+++ b/src/utils_project.js
@@ -200,7 +200,7 @@ go.utils_project = {
         var endpoint = "tracker/"+tracker_id+"/";
         var payload = {
             "complete": true,
-            "completed_at": go.utils.get_today(im.config)
+            "completed_at": go.utils.get_today(im.config).format("YYYY-MM-DD")
         };
 
         return go.utils

--- a/src/utils_project.js
+++ b/src/utils_project.js
@@ -200,7 +200,7 @@ go.utils_project = {
         var endpoint = "tracker/"+tracker_id+"/";
         var payload = {
             "complete": true,
-            "completed_at": go.utils.get_today(im.config).format("YYYY-MM-DD")
+            "completed_at": go.utils.get_now(im.config)
         };
 
         return go.utils

--- a/src/utils_project.js
+++ b/src/utils_project.js
@@ -145,23 +145,6 @@ go.utils_project = {
             });
     },
 
-    // SMS HELPERS
-
-    send_completion_text: function(im, user_id, text_to_add) {
-        var sms_content = "Your results from today's quiz:"+text_to_add;
-        var payload = {
-            "identity": user_id,
-            "content": sms_content
-        };
-        return go.utils
-        .service_api_call("message_sender", "post", null, payload, 'outbound/', im)
-        .then(function(json_post_response) {
-            var outbound_response = json_post_response.data;
-            // Return the outbound id
-            return outbound_response.id;
-        });
-    },
-
     // returns an object; first property represents the number of correct
     // answers, and second the total number of questions asked, and the
     // third the subsequent percentage of correct_answers out of questions asked
@@ -180,6 +163,39 @@ go.utils_project = {
             "percentage": (correct_answers/total_questions).toFixed(2)*100
         };
     },
+
+    // taking identity_uuid and quiz_uuid, returns tracker_uuid
+    init_tracker: function(im, identity_id, quiz_id) {
+        var payload = {
+            "identity": identity_id,
+            "quiz": quiz_id
+        };
+
+        return go.utils
+            .service_api_call("continuous-learning", "post", null, payload, 'tracker/', im)
+            .then(function(json_post_response) {
+                return json_post_response.data;
+        });
+    },
+
+    // SMS HELPERS
+
+    send_completion_text: function(im, user_id, text_to_add) {
+        var sms_content = "Your results from today's quiz:"+text_to_add;
+        var payload = {
+            "identity": user_id,
+            "content": sms_content
+        };
+        return go.utils
+        .service_api_call("message_sender", "post", null, payload, 'outbound/', im)
+        .then(function(json_post_response) {
+            var outbound_response = json_post_response.data;
+            // Return the outbound id
+            return outbound_response.id;
+        });
+    },
+
+
 
     "commas": "commas"
 

--- a/src/utils_project.js
+++ b/src/utils_project.js
@@ -174,6 +174,24 @@ go.utils_project = {
         return go.utils
             .service_api_call("continuous-learning", "post", null, payload, 'tracker/', im)
             .then(function(json_post_response) {
+                return json_post_response.data.tracker_id;
+        });
+    },
+
+    log_quiz_answer: function(im, quiz_question, answer_value, answer_text, answer_correct, response, tracker_id) {
+        var payload = {
+            "question": quiz_question.id,
+            "question_text": quiz_question.question,
+            "answer_value": answer_value,
+            "answer_text": answer_text,
+            "answer_correct": answer_correct,
+            "response_sent": response,
+            "tracker": tracker_id
+        };
+
+        return go.utils
+            .service_api_call("continuous-learning", "post", null, payload, 'answer/', im)
+            .then(function(json_post_response) {
                 return json_post_response.data;
         });
     },

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -1093,5 +1093,156 @@ return [
         }
     },
 
+
+    // 32: log answer for question cb245673-aa41-4302-ac47-qq000000001, answered correctly
+    {
+        "request": {
+            "method": "POST",
+            "headers": {
+                "Authorization": ["Token test_key"],
+                "Content-Type": ["application/json"]
+            },
+            "url": "http://localhost:8003/api/v1/answer/",
+            "data":  {
+                "question": "cb245673-aa41-4302-ac47-qq000000001",
+                "question_text": "Who is tallest?",
+                "answer_value": "nicki",
+                "answer_text": "Nicki",
+                "answer_correct": "True",
+                "response_sent": "Correct! That's why only he bangs his head on the lamp!",
+                "tracker": "cb245673-aa41-4302-ac47-t00000111111"
+            }
+        },
+        "response": {
+            "code": 201,
+            "data": {}
+        }
+    },
+
+    // 33: log answer for question cb245673-aa41-4302-ac47-qq000000001, answered incorrectly
+    {
+        "request": {
+            "method": "POST",
+            "headers": {
+                "Authorization": ["Token test_key"],
+                "Content-Type": ["application/json"]
+            },
+            "url": "http://localhost:8003/api/v1/answer/",
+            "data":  {
+                "question": "cb245673-aa41-4302-ac47-qq000000001",
+                "question_text": "Who is tallest?",
+                "answer_value": "mike",
+                "answer_text": "Mike",
+                "answer_correct": "False",
+                "response_sent": "Incorrect! You need to open your eyes and see it's Nicki!",
+                "tracker": "cb245673-aa41-4302-ac47-t00000111111"
+            }
+        },
+        "response": {
+            "code": 201,
+            "data": {}
+        }
+    },
+
+    // 34: log answer for question cb245673-aa41-4302-ac47-qq000000002, answered correctly
+    {
+        "request": {
+            "method": "POST",
+            "headers": {
+                "Authorization": ["Token test_key"],
+                "Content-Type": ["application/json"]
+            },
+            "url": "http://localhost:8003/api/v1/answer/",
+            "data":  {
+                "question": "cb245673-aa41-4302-ac47-qq000000002",
+                "question_text": "Who is fittest?",
+                "answer_value": "george",
+                "answer_text": "George",
+                "answer_correct": "True",
+                "response_sent": "Correct! He goes to the gym often!",
+                "tracker": "cb245673-aa41-4302-ac47-t00000111111"
+            }
+        },
+        "response": {
+            "code": 201,
+            "data": {}
+        }
+    },
+
+    // 35: log answer for question cb245673-aa41-4302-ac47-qq000000002, answered incorrectly
+    {
+        "request": {
+            "method": "POST",
+            "headers": {
+                "Authorization": ["Token test_key"],
+                "Content-Type": ["application/json"]
+            },
+            "url": "http://localhost:8003/api/v1/answer/",
+            "data":  {
+                "question": "cb245673-aa41-4302-ac47-qq000000002",
+                "question_text": "Who is fittest?",
+                "answer_value": "nicki",
+                "answer_text": "Nicki",
+                "answer_correct": "False",
+                "response_sent": "Incorrect! You need to open your eyes and see it's George!",
+                "tracker": "cb245673-aa41-4302-ac47-t00000111111"
+            }
+        },
+        "response": {
+            "code": 201,
+            "data": {}
+        }
+    },
+
+    // 36: log answer for question cb245673-aa41-4302-ac47-qq000000003, answered correctly
+    {
+        "request": {
+            "method": "POST",
+            "headers": {
+                "Authorization": ["Token test_key"],
+                "Content-Type": ["application/json"]
+            },
+            "url": "http://localhost:8003/api/v1/answer/",
+            "data":  {
+                "question": "cb245673-aa41-4302-ac47-qq000000003",
+                "question_text": "Who is the boss?",
+                "answer_value": "mike",
+                "answer_text": "Mike",
+                "answer_correct": "True",
+                "response_sent": "Correct! That's why he's got the final say!",
+                "tracker": "cb245673-aa41-4302-ac47-t00000111111"
+            }
+        },
+        "response": {
+            "code": 201,
+            "data": {}
+        }
+    },
+
+    // 37: log answer for question cb245673-aa41-4302-ac47-qq000000003, answered incorrectly
+    {
+        "request": {
+            "method": "POST",
+            "headers": {
+                "Authorization": ["Token test_key"],
+                "Content-Type": ["application/json"]
+            },
+            "url": "http://localhost:8003/api/v1/answer/",
+            "data":  {
+                "question": "cb245673-aa41-4302-ac47-qq000000003",
+                "question_text": "Who is the boss?",
+                "answer_value": "nicki",
+                "answer_text": "Nicki",
+                "answer_correct": "False",
+                "response_sent": "Incorrect! You need to open your eyes and see it's Mike!",
+                "tracker": "cb245673-aa41-4302-ac47-t00000111111"
+            }
+        },
+        "response": {
+            "code": 201,
+            "data": {}
+        }
+    },
+
 ];
 };

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -1108,7 +1108,7 @@ return [
                 "question_text": "Who is tallest?",
                 "answer_value": "nicki",
                 "answer_text": "Nicki",
-                "answer_correct": "True",
+                "answer_correct": true,
                 "response_sent": "Correct! That's why only he bangs his head on the lamp!",
                 "tracker": "cb245673-aa41-4302-ac47-t00000111111"
             }
@@ -1133,7 +1133,7 @@ return [
                 "question_text": "Who is tallest?",
                 "answer_value": "mike",
                 "answer_text": "Mike",
-                "answer_correct": "False",
+                "answer_correct": false,
                 "response_sent": "Incorrect! You need to open your eyes and see it's Nicki!",
                 "tracker": "cb245673-aa41-4302-ac47-t00000111111"
             }
@@ -1158,7 +1158,7 @@ return [
                 "question_text": "Who is fittest?",
                 "answer_value": "george",
                 "answer_text": "George",
-                "answer_correct": "True",
+                "answer_correct": true,
                 "response_sent": "Correct! He goes to the gym often!",
                 "tracker": "cb245673-aa41-4302-ac47-t00000111111"
             }
@@ -1183,7 +1183,7 @@ return [
                 "question_text": "Who is fittest?",
                 "answer_value": "nicki",
                 "answer_text": "Nicki",
-                "answer_correct": "False",
+                "answer_correct": false,
                 "response_sent": "Incorrect! You need to open your eyes and see it's George!",
                 "tracker": "cb245673-aa41-4302-ac47-t00000111111"
             }
@@ -1208,7 +1208,7 @@ return [
                 "question_text": "Who is the boss?",
                 "answer_value": "mike",
                 "answer_text": "Mike",
-                "answer_correct": "True",
+                "answer_correct": true,
                 "response_sent": "Correct! That's why he's got the final say!",
                 "tracker": "cb245673-aa41-4302-ac47-t00000111111"
             }
@@ -1233,7 +1233,7 @@ return [
                 "question_text": "Who is the boss?",
                 "answer_value": "nicki",
                 "answer_text": "Nicki",
-                "answer_correct": "False",
+                "answer_correct": false,
                 "response_sent": "Incorrect! You need to open your eyes and see it's Mike!",
                 "tracker": "cb245673-aa41-4302-ac47-t00000111111"
             }
@@ -1254,7 +1254,7 @@ return [
             },
             "url": "http://localhost:8003/api/v1/tracker/cb245673-aa41-4302-ac47-t00000111111/",
             "data":  {
-                "complete": "True",
+                "complete": true,
                 "completed_at": "2016-04-04T22:00:00.000Z"
             }
         },

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -1255,7 +1255,7 @@ return [
             "url": "http://localhost:8003/api/v1/tracker/cb245673-aa41-4302-ac47-t00000111111/",
             "data":  {
                 "complete": true,
-                "completed_at": "2016-04-05"
+                "completed_at": "2016-04-05 15:30:02"
             }
         },
         "response": {

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -1244,5 +1244,25 @@ return [
         }
     },
 
+    // 38: patch tracker cb245673-aa41-4302-ac47-t00000111111 with completed status
+    {
+        "request": {
+            "method": "PATCH",
+            "headers": {
+                "Authorization": ["Token test_key"],
+                "Content-Type": ["application/json"]
+            },
+            "url": "http://localhost:8003/api/v1/tracker/cb245673-aa41-4302-ac47-t00000111111/",
+            "data":  {
+                "complete": "True",
+                "completed_at": "2016-04-04T22:00:00.000Z"
+            }
+        },
+        "response": {
+            "code": 200,
+            "data": {}
+        }
+    },
+
 ];
 };

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -1069,5 +1069,29 @@ return [
         }
     },
 
+    // 31: create tracker for
+    // identity cb245673-aa41-4302-ac47-000000000111,
+    // quiz cb245673-aa41-4302-ac47-q00000000111
+    {
+        "request": {
+            "method": "POST",
+            "headers": {
+                "Authorization": ["Token test_key"],
+                "Content-Type": ["application/json"]
+            },
+            "url": "http://localhost:8003/api/v1/tracker/",
+            "data":  {
+                "identity": "cb245673-aa41-4302-ac47-000000000111",
+                "quiz": "cb245673-aa41-4302-ac47-q00000000111"
+            }
+        },
+        "response": {
+            "code": 201,
+            "data": {
+                "tracker_id": "cb245673-aa41-4302-ac47-t00000111111"
+            }
+        }
+    },
+
 ];
 };

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -1255,7 +1255,7 @@ return [
             "url": "http://localhost:8003/api/v1/tracker/cb245673-aa41-4302-ac47-t00000111111/",
             "data":  {
                 "complete": true,
-                "completed_at": "2016-04-04T22:00:00.000Z"
+                "completed_at": "2016-04-05"
             }
         },
         "response": {

--- a/test/ussdapp.test.js
+++ b/test/ussdapp.test.js
@@ -309,7 +309,7 @@ describe("UoP TB registration/quiz app", function() {
                         reply: "Thank you for completing your quiz. You correctly answered 3 of 3 questions. Your score is 100%"
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api,[0,6,9,13,14,15,25,26,27,28,31,32,34,36]);
+                        go.utils.check_fixtures_used(api,[0,6,9,13,14,15,25,26,27,28,31,32,34,36,38]);
                     })
                     .run();
             });
@@ -349,7 +349,7 @@ describe("UoP TB registration/quiz app", function() {
                         reply: "Thank you for completing your quiz. You correctly answered 1 of 3 questions. Your score is 33%"
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api,[0,6,9,13,14,15,25,26,27,29,31,33,34,37]);
+                        go.utils.check_fixtures_used(api,[0,6,9,13,14,15,25,26,27,29,31,33,34,37,38]);
                     })
                     .run();
             });
@@ -370,7 +370,7 @@ describe("UoP TB registration/quiz app", function() {
                         reply: "Thank you for completing your quiz. You correctly answered 1 of 3 questions. Your score is 33%"
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api,[0,6,9,13,14,15,25,26,27,30,31,33,35,36]);
+                        go.utils.check_fixtures_used(api,[0,6,9,13,14,15,25,26,27,30,31,33,35,36,38]);
                     })
                     .run();
             });

--- a/test/ussdapp.test.js
+++ b/test/ussdapp.test.js
@@ -18,7 +18,7 @@ describe("UoP TB registration/quiz app", function() {
                     name: 'ussd-app-test',
                     country_code: '267',  // botswana
                     channel: '*120*8864*0000#',
-                    testing_today: '2016-04-05',
+                    testing_today: '2016-04-05 15:30:02',
                     randomize_quizzes: false,
                     randomize_questions: false,
                     services: {

--- a/test/ussdapp.test.js
+++ b/test/ussdapp.test.js
@@ -198,7 +198,7 @@ describe("UoP TB registration/quiz app", function() {
                         ].join('\n')
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api,[0,6,9,13,31]);
+                        go.utils.check_fixtures_used(api,[0,6,9,13,31,32]);
                     })
                     .run();
             });
@@ -220,7 +220,7 @@ describe("UoP TB registration/quiz app", function() {
                         ].join('\n')
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api,[0,6,9,13,14,25,26,31]);
+                        go.utils.check_fixtures_used(api,[0,6,9,13,14,25,26,31,32]);
                     })
                     .run();
             });
@@ -241,7 +241,7 @@ describe("UoP TB registration/quiz app", function() {
                         ].join('\n')
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api,[0,6,9,13,14,25,26,31]);
+                        go.utils.check_fixtures_used(api,[0,6,9,13,14,25,26,31,32,34]);
                     })
                     .run();
             });
@@ -265,7 +265,7 @@ describe("UoP TB registration/quiz app", function() {
                         ].join('\n')
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api,[0,6,9,13,14,15,25,26,31]);
+                        go.utils.check_fixtures_used(api,[0,6,9,13,14,15,25,26,31,32,34]);
                     })
                     .run();
             });
@@ -288,7 +288,7 @@ describe("UoP TB registration/quiz app", function() {
                         ].join('\n')
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api,[0,6,9,13,14,15,25,26,31]);
+                        go.utils.check_fixtures_used(api,[0,6,9,13,14,15,25,26,31,32,34,36]);
                     })
                     .run();
             });
@@ -309,7 +309,7 @@ describe("UoP TB registration/quiz app", function() {
                         reply: "Thank you for completing your quiz. You correctly answered 3 of 3 questions. Your score is 100%"
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api,[0,6,9,13,14,15,25,26,27,28,31]);
+                        go.utils.check_fixtures_used(api,[0,6,9,13,14,15,25,26,27,28,31,32,34,36]);
                     })
                     .run();
             });
@@ -349,7 +349,7 @@ describe("UoP TB registration/quiz app", function() {
                         reply: "Thank you for completing your quiz. You correctly answered 1 of 3 questions. Your score is 33%"
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api,[0,6,9,13,14,15,25,26,27,29,31]);
+                        go.utils.check_fixtures_used(api,[0,6,9,13,14,15,25,26,27,29,31,33,34,37]);
                     })
                     .run();
             });
@@ -370,7 +370,7 @@ describe("UoP TB registration/quiz app", function() {
                         reply: "Thank you for completing your quiz. You correctly answered 1 of 3 questions. Your score is 33%"
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api,[0,6,9,13,14,15,25,26,27,30,31]);
+                        go.utils.check_fixtures_used(api,[0,6,9,13,14,15,25,26,27,30,31,33,35,36]);
                     })
                     .run();
             });

--- a/test/ussdapp.test.js
+++ b/test/ussdapp.test.js
@@ -160,7 +160,7 @@ describe("UoP TB registration/quiz app", function() {
                         ].join('\n')
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api,[0,6,9,13]);
+                        go.utils.check_fixtures_used(api,[0,6,9,13,31]);
                     })
                     .run();
             });
@@ -198,7 +198,7 @@ describe("UoP TB registration/quiz app", function() {
                         ].join('\n')
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api,[0,6,9,13]);
+                        go.utils.check_fixtures_used(api,[0,6,9,13,31]);
                     })
                     .run();
             });
@@ -220,7 +220,7 @@ describe("UoP TB registration/quiz app", function() {
                         ].join('\n')
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api,[0,6,9,13,14,25,26]);
+                        go.utils.check_fixtures_used(api,[0,6,9,13,14,25,26,31]);
                     })
                     .run();
             });
@@ -241,7 +241,7 @@ describe("UoP TB registration/quiz app", function() {
                         ].join('\n')
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api,[0,6,9,13,14,25,26]);
+                        go.utils.check_fixtures_used(api,[0,6,9,13,14,25,26,31]);
                     })
                     .run();
             });
@@ -265,7 +265,7 @@ describe("UoP TB registration/quiz app", function() {
                         ].join('\n')
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api,[0,6,9,13,14,15,25,26]);
+                        go.utils.check_fixtures_used(api,[0,6,9,13,14,15,25,26,31]);
                     })
                     .run();
             });
@@ -288,7 +288,7 @@ describe("UoP TB registration/quiz app", function() {
                         ].join('\n')
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api,[0,6,9,13,14,15,25,26]);
+                        go.utils.check_fixtures_used(api,[0,6,9,13,14,15,25,26,31]);
                     })
                     .run();
             });
@@ -309,7 +309,7 @@ describe("UoP TB registration/quiz app", function() {
                         reply: "Thank you for completing your quiz. You correctly answered 3 of 3 questions. Your score is 100%"
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api,[0,6,9,13,14,15,25,26,27,28]);
+                        go.utils.check_fixtures_used(api,[0,6,9,13,14,15,25,26,27,28,31]);
                     })
                     .run();
             });
@@ -349,7 +349,7 @@ describe("UoP TB registration/quiz app", function() {
                         reply: "Thank you for completing your quiz. You correctly answered 1 of 3 questions. Your score is 33%"
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api,[0,6,9,13,14,15,25,26,27,29]);
+                        go.utils.check_fixtures_used(api,[0,6,9,13,14,15,25,26,27,29,31]);
                     })
                     .run();
             });
@@ -370,7 +370,7 @@ describe("UoP TB registration/quiz app", function() {
                         reply: "Thank you for completing your quiz. You correctly answered 1 of 3 questions. Your score is 33%"
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api,[0,6,9,13,14,15,25,26,27,30]);
+                        go.utils.check_fixtures_used(api,[0,6,9,13,14,15,25,26,27,30,31]);
                     })
                     .run();
             });


### PR DESCRIPTION
The backend uses the concept of a `tracker` now to keep answers grouped together. On start of a quiz session, it should be POSTed to with the identity uuid and the quiz: https://github.com/westerncapelabs/seed-continuous-learning/blob/develop/quizzes/tests.py#L255-L263

In response you'll get a tracker UUID should you be provided with each answer log: https://github.com/westerncapelabs/seed-continuous-learning/blob/develop/quizzes/tests.py#L315-L326

Once completed, the tracker should be PATCHed to have a completed status: https://github.com/westerncapelabs/seed-continuous-learning/blob/develop/quizzes/tests.py#L291-L297
